### PR TITLE
clunking case damage fix

### DIFF
--- a/base/scripts/code.player.cs
+++ b/base/scripts/code.player.cs
@@ -255,8 +255,12 @@ function Player::onDamage(%this,%type,%value,%pos,%vec,%mom,%vertPos,%quadrant,%
             //clunking stat
             if( (%type == $LandingDamageType) && (%newValue >= 10) ) {
                 zadmin::ActiveMessage::All( PlayerClunk, %shooterClient );
+                //
+                Collector::onPlayerClunk( %shooterClient );
                 return;
             }
+            else if ( (%type == $LandingDamageType) && (%newValue < 10) ) { return; }
+            else {}
             
             if ( (%type == $ShrapnelDamageType) && (%newValue == 67.1989) ) {
                 //MessageAll(0, "MID AIR NADE DETECTED");

--- a/base/scripts/code.player.cs
+++ b/base/scripts/code.player.cs
@@ -256,7 +256,7 @@ function Player::onDamage(%this,%type,%value,%pos,%vec,%mom,%vertPos,%quadrant,%
             if( (%type == $LandingDamageType) && (%newValue >= 10) ) {
                 zadmin::ActiveMessage::All( PlayerClunk, %shooterClient );
                 //
-                Collector::onPlayerClunk( %shooterClient );
+                //Collector::onPlayerClunk( %shooterClient );
                 return;
             }
             else if ( (%type == $LandingDamageType) && (%newValue < 10) ) { return; }


### PR DESCRIPTION
this fixes a little issue where if user has landing damage of less then 10, it adds that damage to their intake (from the enemy)